### PR TITLE
fix(dayjs.add): support daylight saving time

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -240,7 +240,7 @@ class Dayjs {
     }
     const instanceFactorySet = (n) => {
       const date = new Date(this.$d)
-      date.setDate(date.getDate() + n * number)
+      date.setDate(date.getDate() + (n * number))
       return wrapper(date, this)
     }
     if (unit === C.M) {

--- a/src/index.js
+++ b/src/index.js
@@ -238,11 +238,22 @@ class Dayjs {
       const date = this.set(C.DATE, 1).set(u, n + number)
       return date.set(C.DATE, Math.min(this.$D, date.daysInMonth()))
     }
+    const instanceFactorySet = (n) => {
+      const date = new Date(this.$d)
+      date.setDate(date.getDate() + n * number)
+      return wrapper(date, this)
+    }
     if (unit === C.M) {
       return instanceFactory(C.M, this.$M)
     }
     if (unit === C.Y) {
       return instanceFactory(C.Y, this.$y)
+    }
+    if (unit === C.D) {
+      return instanceFactorySet(1)
+    }
+    if (unit === C.W) {
+      return instanceFactorySet(7)
     }
     let step
     switch (unit) {
@@ -251,12 +262,6 @@ class Dayjs {
         break
       case C.H:
         step = C.MILLISECONDS_A_HOUR
-        break
-      case C.D:
-        step = C.MILLISECONDS_A_DAY
-        break
-      case C.W:
-        step = C.MILLISECONDS_A_WEEK
         break
       case C.S:
         step = C.MILLISECONDS_A_SECOND


### PR DESCRIPTION
It's not safe to add 24 hours to manipulate date, There are 2 days of the year that do not have 24 hours
In order to get rid of this issue its good to use build-in setDate
See: https://en.wikipedia.org/wiki/Daylight_saving_time