### PR TITLE
Fix locale that does not have plural form

### DIFF
--- a/src/locale/id.js
+++ b/src/locale/id.js
@@ -16,16 +16,16 @@ const locale = {
     future: 'dalam %s',
     past: '%s yang lalu',
     s: 'beberapa detik',
-    m: 'semenit',
-    mm: '%d menit',
-    h: 'sejam',
-    hh: '%d jam',
-    d: 'sehari',
-    dd: '%d hari',
-    M: 'sebulan',
-    MM: '%d bulan',
-    y: 'setahun',
-    yy: '%d tahun'
+    m: '%d menit',
+    mm: '',
+    h: '%d jam',
+    hh: '',
+    d: '%d hari',
+    dd: '',
+    M: '%d bulan',
+    MM: '',
+    y: '%d tahun',
+    yy: ''
   },
   ordinal: n => `${n}.`
 }

--- a/src/plugin/relativeTime/index.js
+++ b/src/plugin/relativeTime/index.js
@@ -136,7 +136,7 @@ export default (o, c, d) => {
         const key = t.l
         if (key.length === 1) {
           // Handle singular using a special text without any number
-          out = loc[key]
+          out = loc[key].replace('%d', 1)
         } else {
           // Choose the plural form using the index decided by the plural rule
           const pluralForms = loc[key]


### PR DESCRIPTION
Currently there is a bug with Indonesian locale since this library uses plural rules and Indonesian doesn't have plural form (though we could use `se-` to replace 1, like `sehari` instead of `1 hari`). This caused relativeTime plugin to always use singular form `sehari (1 day)` when it should be `%d hari` if the number is more than 1.